### PR TITLE
App's splash is now the peer logo

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
 		"orientation": "portrait",
 		"icon": "./assets/icon.png",
 		"splash": {
-			"image": "./assets/splash.png",
+			"image": "./assets/icon.png",
 			"resizeMode": "contain",
 			"backgroundColor": "#ffffff"
 		},


### PR DESCRIPTION
The peer logo was added as the app's icon, but was not added as the splash. I went ahead and made that tiny change so the splash isn't empty anymore.﻿
