### PR TITLE
Add codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 85%
+        threshold: 5%


### PR DESCRIPTION
Adding this configuration file will allow all of the CI to pass even if the test coverage drops a little bit. It will only fail if the coverage drops below 85%, or more than 5% at once.﻿
