### PR TITLE
Rating is loaded upon entering a place's details screen

### DIFF
--- a/__tests__/authentication/CreateAccountScreen.test.tsx
+++ b/__tests__/authentication/CreateAccountScreen.test.tsx
@@ -33,6 +33,7 @@ beforeEach(() => {
 			setPage={mockSetPage}
 			setPlaceID={mockSetPlaceID}
 			goToSubmitRating={mockGoToSubmitRating}
+			setLoggedIn={jest.fn()}
 		/>
 	);
 });

--- a/__tests__/authentication/LoginScreen.test.tsx
+++ b/__tests__/authentication/LoginScreen.test.tsx
@@ -33,6 +33,7 @@ beforeEach(() => {
 			setPage={mockSetPage}
 			setPlaceID={mockSetPlaceID}
 			goToSubmitRating={mockGoToSubmitRating}
+			setLoggedIn={jest.fn()}
 		/>
 	);
 });

--- a/__tests__/components/NearbyPlaces.test.tsx
+++ b/__tests__/components/NearbyPlaces.test.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { cleanup, fireEvent, render, RenderAPI } from "@testing-library/react-native";
 import type { LocationObject } from "expo-location";
-import { useLocation } from "../src/hooks/useLocation";
-import { useNearbyPlaces, BusinessStatus } from "../src/hooks/useNearbyPlaces";
-import { RelativeDirectionOutput, useCompass } from "../src/hooks/useCompass";
-import { computeDistanceFeet } from "../src/util/distance";
+import { useLocation } from "../../src/hooks/useLocation";
+import { useNearbyPlaces, BusinessStatus } from "../../src/hooks/useNearbyPlaces";
+import { RelativeDirectionOutput, useCompass } from "../../src/hooks/useCompass";
+import { computeDistanceFeet } from "../../src/util/distance";
 import {
 	PlaceDetailsWithAccesibilityData,
 	PlaceWithAccesibilityData,
-} from "../src/util/placeTypes";
-import { useFetchPlace } from "../src/hooks/useFetchPlace";
-import MainScreen from "../src/screens/MainScreen";
+} from "../../src/util/placeTypes";
+import { useFetchPlace } from "../../src/hooks/useFetchPlace";
+import MainScreen from "../../src/screens/MainScreen";
 
 // mock use location to prevent querying for location data
-jest.mock("../src/hooks/useLocation");
+jest.mock("../../src/hooks/useLocation");
 const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
 const mockLocation: LocationObject = {
 	coords: {
@@ -29,7 +29,7 @@ const mockLocation: LocationObject = {
 };
 
 // mock use compass to prevent querying for compass data
-jest.mock("../src/hooks/useCompass");
+jest.mock("../../src/hooks/useCompass");
 const mockUseCompass = useCompass as jest.MockedFunction<typeof useCompass>;
 const mockRelativeDirection = (): RelativeDirectionOutput => {
 	return {
@@ -40,12 +40,12 @@ const mockRelativeDirection = (): RelativeDirectionOutput => {
 };
 
 // mock compute distance because user location is nonsense
-jest.mock("../src/util/distance.ts");
+jest.mock("../../src/util/distance.ts");
 const mockComputeDistance = computeDistanceFeet as jest.MockedFunction<typeof computeDistanceFeet>;
 const mockDistance = 5.58;
 
 // mock nearby places to prevent calls to remote server
-jest.mock("../src/hooks/useNearbyPlaces");
+jest.mock("../../src/hooks/useNearbyPlaces");
 const mockNearbyPlaces = useNearbyPlaces as jest.MockedFunction<typeof useNearbyPlaces>;
 const mockPlaces: Partial<PlaceWithAccesibilityData>[] = [
 	{
@@ -62,7 +62,7 @@ const mockPlaces: Partial<PlaceWithAccesibilityData>[] = [
 	},
 ];
 
-jest.mock("../src/hooks/useFetchPlace");
+jest.mock("../../src/hooks/useFetchPlace");
 const mockUseFetchPlace = useFetchPlace as jest.MockedFunction<typeof useFetchPlace>;
 
 const mockPlaceDetails: PlaceDetailsWithAccesibilityData = {

--- a/__tests__/components/PlaceList.test.tsx
+++ b/__tests__/components/PlaceList.test.tsx
@@ -1,24 +1,24 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react-native";
-import { useNearbyPlaces } from "../src/hooks/useNearbyPlaces";
+import { useNearbyPlaces } from "../../src/hooks/useNearbyPlaces";
 import { PlacePhoto } from "@googlemaps/google-maps-services-js";
-import { computeDistanceMi } from "../src/util/distance";
+import { computeDistanceMi } from "../../src/util/distance";
 import {
 	PlaceDetailsWithAccesibilityData,
 	PlaceWithAccesibilityData,
-} from "../src/util/placeTypes";
-import { useFetchPlace } from "../src/hooks/useFetchPlace";
-import MainScreen from "../src/screens/MainScreen";
+} from "../../src/util/placeTypes";
+import { useFetchPlace } from "../../src/hooks/useFetchPlace";
+import MainScreen from "../../src/screens/MainScreen";
 
 afterEach(cleanup);
 jest.useFakeTimers();
 
 // mock distance computation because user location is not available during testing
-jest.mock("../src/util/distance");
+jest.mock("../../src/util/distance");
 const mockDistMi = computeDistanceMi as jest.MockedFunction<typeof computeDistanceMi>;
 
 // mock axios to prevent calls to remote server for nearby places
-jest.mock("../src/hooks/useNearbyPlaces");
+jest.mock("../../src/hooks/useNearbyPlaces");
 const mockNearbyPlaces = useNearbyPlaces as jest.MockedFunction<typeof useNearbyPlaces>;
 const mockPhotosField: PlacePhoto[] = [
 	{
@@ -71,7 +71,7 @@ const mockPlaces: PlaceWithAccesibilityData[] = [
 ];
 mockNearbyPlaces.mockReturnValue({ nearbyPlaces: mockPlaces });
 
-jest.mock("../src/hooks/useFetchPlace");
+jest.mock("../../src/hooks/useFetchPlace");
 const mockUseFetchPlace = useFetchPlace as jest.MockedFunction<typeof useFetchPlace>;
 
 const mockPlaceDetails: PlaceDetailsWithAccesibilityData = {

--- a/__tests__/components/SelectionBox.test.tsx
+++ b/__tests__/components/SelectionBox.test.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { cleanup, render, fireEvent, waitFor, RenderAPI } from "@testing-library/react-native";
-import { enabledFiltersMap } from "../src/components/SelectionBox";
-import { useNearbyPlaces } from "../src/hooks/useNearbyPlaces";
+import { enabledFiltersMap } from "../../src/components/SelectionBox";
+import { useNearbyPlaces } from "../../src/hooks/useNearbyPlaces";
 import {
 	PlaceDetailsWithAccesibilityData,
 	PlaceWithAccesibilityData,
-} from "../src/util/placeTypes";
-import { useFetchPlace } from "../src/hooks/useFetchPlace";
-import MainScreen from "../src/screens/MainScreen";
+} from "../../src/util/placeTypes";
+import { useFetchPlace } from "../../src/hooks/useFetchPlace";
+import MainScreen from "../../src/screens/MainScreen";
 
-jest.mock("../src/hooks/useNearbyPlaces");
+jest.mock("../../src/hooks/useNearbyPlaces");
 const mockUseNearbyPlaces = useNearbyPlaces as jest.MockedFunction<typeof useNearbyPlaces>;
 mockUseNearbyPlaces.mockImplementation(
 	(placeType?): { nearbyPlaces: PlaceWithAccesibilityData[] | undefined } => {
@@ -20,7 +20,7 @@ mockUseNearbyPlaces.mockImplementation(
 	}
 );
 
-jest.mock("../src/hooks/useFetchPlace");
+jest.mock("../../src/hooks/useFetchPlace");
 const mockUseFetchPlace = useFetchPlace as jest.MockedFunction<typeof useFetchPlace>;
 
 const mockPlaceDetails: PlaceDetailsWithAccesibilityData = {

--- a/__tests__/hooks/useCompass.test.tsx
+++ b/__tests__/hooks/useCompass.test.tsx
@@ -2,7 +2,7 @@ import { LocationType, Place } from "@googlemaps/google-maps-services-js";
 import { cleanup, render, RenderAPI } from "@testing-library/react-native";
 import React from "react";
 import { View, Text } from "react-native";
-import { useCompass } from "../src/hooks/useCompass";
+import { useCompass } from "../../src/hooks/useCompass";
 import { LocationObject } from "expo-location";
 
 afterEach(cleanup);

--- a/__tests__/hooks/useNearbyPlaces.test.tsx
+++ b/__tests__/hooks/useNearbyPlaces.test.tsx
@@ -1,15 +1,15 @@
-import { useLocation } from "../src/hooks/useLocation";
-import { useNearbyPlaces } from "../src/hooks/useNearbyPlaces";
+import { useLocation } from "../../src/hooks/useLocation";
+import { useNearbyPlaces } from "../../src/hooks/useNearbyPlaces";
 import axios from "axios";
 import { Place } from "@googlemaps/google-maps-services-js";
 import { LocationObject } from "expo-location";
 import { renderHook, cleanup } from "@testing-library/react-hooks";
 import { waitFor } from "@testing-library/react-native";
-import { BusinessStatus } from "../src/hooks/useNearbyPlaces";
+import { BusinessStatus } from "../../src/hooks/useNearbyPlaces";
 
 jest.useFakeTimers();
 
-jest.mock("../src/hooks/useLocation");
+jest.mock("../../src/hooks/useLocation");
 
 const mockLocation: LocationObject = {
 	coords: {

--- a/__tests__/hooks/usePreviousRating.test.tsx
+++ b/__tests__/hooks/usePreviousRating.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Text, View } from "react-native";
+import { usePreviousRating } from "../../src/hooks/usePreviousRating";
+import axios from "axios";
+import { Rating } from "../../src/util/ratingTypes";
+import { render, RenderAPI, waitFor } from "@testing-library/react-native";
+
+const mockRating: Rating = {
+	_id: "7065616e7574627574746572",
+	userID: "67726170656a656c6c79",
+	placeID: "ChIJZxUD-qwtpTgRbqMViMXDJUg",
+	braille: 3,
+	fontReadability: 3,
+	navigability: 3,
+	staffHelpfulness: 3,
+	guideDogFriendly: 3,
+	comment: null,
+	dateCreated: new Date(),
+};
+
+jest.mock("axios");
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const mockAxiosGet = axios.get as jest.MockedFunction<typeof axios.get>;
+mockAxiosGet.mockResolvedValue({ data: mockRating });
+
+const PreviousRatingComponent: React.FC = () => {
+	const previousRating = usePreviousRating("peer@gmail.com", "ChIJZxUD-qwtpTgRbqMViMXDJUg");
+
+	if (previousRating) {
+		return (
+			<View>
+				<Text>{previousRating.braille}</Text>
+				<Text>{previousRating.fontReadability}</Text>
+				<Text>{previousRating.guideDogFriendly}</Text>
+				<Text>{previousRating.navigability}</Text>
+				<Text>{previousRating.staffHelpfulness}</Text>
+			</View>
+		);
+	} else {
+		return (
+			<View>
+				<Text>Null</Text>
+			</View>
+		);
+	}
+};
+
+let tr: RenderAPI;
+beforeEach(() => {
+	tr = render(<PreviousRatingComponent />);
+});
+
+describe("usePreviousRating tests", () => {
+	it("gets the rating if the server returns a rating", async () => {
+		await waitFor(() => {
+			expect(tr.getAllByText("3")).toBeDefined();
+		});
+	});
+
+	it("returns null if the user has not rated the place yet", async () => {
+		mockAxiosGet.mockResolvedValueOnce(null);
+		await waitFor(() => {
+			expect(tr.getByText("Null")).toBeDefined();
+		});
+	});
+});

--- a/__tests__/screens/DetailedViewScreen.test.tsx
+++ b/__tests__/screens/DetailedViewScreen.test.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { cleanup, render, fireEvent, RenderAPI } from "@testing-library/react-native";
 import axios, { AxiosResponse } from "axios";
-import { useNearbyPlaces } from "../src/hooks/useNearbyPlaces";
-import { PlaceWithAccesibilityData } from "../src/util/placeTypes";
+import { useNearbyPlaces } from "../../src/hooks/useNearbyPlaces";
+import { PlaceWithAccesibilityData } from "../../src/util/placeTypes";
 import { PlaceDetailsResponseData } from "@googlemaps/google-maps-services-js";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import MainScreen from "../src/screens/MainScreen";
+import MainScreen from "../../src/screens/MainScreen";
 
 const mockNameString = "Julio's OneDrive Installation Services";
 const mockAddressString = "123 Microsoft Road";
 
-jest.mock("../src/hooks/useNearbyPlaces");
+jest.mock("../../src/hooks/useNearbyPlaces");
 const mockNearbyPlaces = useNearbyPlaces as jest.MockedFunction<typeof useNearbyPlaces>;
 
 const mockPlaces: PlaceWithAccesibilityData[] = [

--- a/__tests__/screens/SubmitRatingScreen.test.tsx
+++ b/__tests__/screens/SubmitRatingScreen.test.tsx
@@ -5,8 +5,8 @@ import {
 	PLACE_ATTRIBUTES,
 	SUBMIT,
 	getIncrementRatingButtonLabel,
-} from "../src/util/strings";
-import SubmitRatingScreen, { DEFAULT_INTERIM_RATING } from "../src/screens/SubmitRatingScreen";
+} from "../../src/util/strings";
+import SubmitRatingScreen, { DEFAULT_INTERIM_RATING } from "../../src/screens/SubmitRatingScreen";
 
 const mockNameString = "Julio's OneDrive Installation Services";
 const mockPlaceID = "oiluj";
@@ -14,7 +14,9 @@ const mockPlaceID = "oiluj";
 let tr: RenderAPI;
 beforeEach(() => {
 	// press place name
-	tr = render(<SubmitRatingScreen placeID={mockPlaceID} placeName={mockNameString} />);
+	tr = render(
+		<SubmitRatingScreen placeID={mockPlaceID} placeName={mockNameString} setPage={jest.fn()} />
+	);
 });
 afterEach(cleanup);
 
@@ -62,7 +64,7 @@ describe("Submit rating screen tests", () => {
 
 	it("renders a plus and minus button even if the place name is missing", () => {
 		// no name!
-		const tr = render(<SubmitRatingScreen placeID={mockPlaceID} />);
+		const tr = render(<SubmitRatingScreen placeID={mockPlaceID} setPage={jest.fn()} />);
 
 		for (const attribute of PLACE_ATTRIBUTES) {
 			expect(

--- a/__tests__/screens/SubmitRatingScreen.test.tsx
+++ b/__tests__/screens/SubmitRatingScreen.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { cleanup, render, RenderAPI } from "@testing-library/react-native";
 import {
-	CANCEL,
+	S_CANCEL,
 	PLACE_ATTRIBUTES,
-	SUBMIT,
+	S_SUBMIT,
 	getIncrementRatingButtonLabel,
 } from "../../src/util/strings";
 import SubmitRatingScreen, { DEFAULT_INTERIM_RATING } from "../../src/screens/SubmitRatingScreen";
@@ -55,11 +55,11 @@ describe("Submit rating screen tests", () => {
 	});
 
 	it("renders a cancel button", () => {
-		expect(tr.queryByText(CANCEL)).not.toBeNull();
+		expect(tr.queryByText(S_CANCEL)).not.toBeNull();
 	});
 
 	it("renders a submit button", () => {
-		expect(tr.queryByText(SUBMIT)).not.toBeNull();
+		expect(tr.queryByText(S_SUBMIT)).not.toBeNull();
 	});
 
 	it("renders a plus and minus button even if the place name is missing", () => {

--- a/__tests__/util/distance.test.ts
+++ b/__tests__/util/distance.test.ts
@@ -1,4 +1,4 @@
-import { computeDistanceFeet, computeDistanceMi } from "../src/util/distance";
+import { computeDistanceFeet, computeDistanceMi } from "../../src/util/distance";
 
 describe("distance util function tests", () => {
 	it("returns undefined if any inputs are undefined", () => {

--- a/__tests__/util/ratings.test.ts
+++ b/__tests__/util/ratings.test.ts
@@ -1,9 +1,9 @@
-import { PlaceWithAccesibilityData } from "../src/util/placeTypes";
+import { PlaceWithAccesibilityData } from "../../src/util/placeTypes";
 import {
 	accessibilityRatingToString,
 	getAverageA11yRating,
 	getPlaceRatingString,
-} from "../src/util/processA11yRatings";
+} from "../../src/util/processA11yRatings";
 
 const sampleRating: PlaceWithAccesibilityData["accessibilityData"] = {
 	_id: "test",

--- a/src/hooks/usePreviousRating.ts
+++ b/src/hooks/usePreviousRating.ts
@@ -4,13 +4,10 @@ import { SERVER_BASE_URL } from "../util/env";
 import { Rating } from "../util/ratingTypes";
 
 // email may be undefined if the user is not logged in
-export const usePreviousRating = ({
-	email,
-	placeID,
-}: {
-	email?: string | null;
-	placeID?: string;
-}): { previousRating?: Rating | null } => {
+export const usePreviousRating = (
+	email?: string | null,
+	placeID?: string
+): Rating | null | undefined => {
 	const [previousRating, setPreviousRating] = useState<Rating | undefined | null>(undefined);
 
 	useEffect(() => {
@@ -24,5 +21,5 @@ export const usePreviousRating = ({
 		})();
 	}, [placeID]);
 
-	return { previousRating };
+	return previousRating;
 };

--- a/src/hooks/usePreviousRating.ts
+++ b/src/hooks/usePreviousRating.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { SERVER_BASE_URL } from "../util/env";
+import { Rating } from "../util/ratingTypes";
+
+// email may be undefined if the user is not logged in
+export const usePreviousRating = ({
+	email,
+	placeID,
+}: {
+	email?: string;
+	placeID?: string;
+}): { previousRating?: Rating | null } => {
+	const [previousRating, setPreviousRating] = useState<Rating | undefined | null>(undefined);
+
+	useEffect(() => {
+		(async () => {
+			if (placeID && email) {
+				const result = await axios.get<Rating | null>(
+					`${SERVER_BASE_URL}/getPotentialRating/${email}/${placeID}`
+				);
+				setPreviousRating(result.data);
+			}
+		})();
+	}, [placeID]);
+
+	return { previousRating };
+};

--- a/src/hooks/usePreviousRating.ts
+++ b/src/hooks/usePreviousRating.ts
@@ -8,7 +8,7 @@ export const usePreviousRating = ({
 	email,
 	placeID,
 }: {
-	email?: string;
+	email?: string | null;
 	placeID?: string;
 }): { previousRating?: Rating | null } => {
 	const [previousRating, setPreviousRating] = useState<Rating | undefined | null>(undefined);

--- a/src/screens/CreateAccountScreen.tsx
+++ b/src/screens/CreateAccountScreen.tsx
@@ -11,6 +11,7 @@ type CreateAccountScreenProps = {
 	setPage: (screen: Screen) => void;
 	setPlaceID: Dispatch<SetStateAction<string | undefined>>;
 	goToSubmitRating: () => void;
+	setLoggedIn: Dispatch<React.SetStateAction<boolean>>;
 };
 
 const CreateAccount: React.FC<CreateAccountScreenProps> = ({
@@ -18,11 +19,13 @@ const CreateAccount: React.FC<CreateAccountScreenProps> = ({
 	placeID,
 	setPlaceID,
 	goToSubmitRating,
+	setLoggedIn,
 }) => {
 	const { validateEmail, hashPassword, email, password, errorMsg, setErrorMsg } =
 		useAuthentication();
 
 	const setPageAndSubmitRating = () => {
+		setLoggedIn(true);
 		goToSubmitRating();
 		if (placeID) {
 			setPlaceID(placeID);

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -11,6 +11,7 @@ type LogInScreenProps = {
 	setPage: (screen: Screen) => void;
 	setPlaceID: Dispatch<SetStateAction<string | undefined>>;
 	goToSubmitRating: () => void;
+	setLoggedIn: Dispatch<React.SetStateAction<boolean>>;
 };
 
 const LogInScreen: React.FC<LogInScreenProps> = ({
@@ -18,11 +19,13 @@ const LogInScreen: React.FC<LogInScreenProps> = ({
 	placeID,
 	setPlaceID,
 	goToSubmitRating,
+	setLoggedIn,
 }) => {
 	const { validateEmail, hashPassword, email, errorMsg, setErrorMsg, password } =
 		useAuthentication();
 
 	const setPageAndSubmitRating = () => {
+		setLoggedIn(true);
 		goToSubmitRating();
 		if (placeID) {
 			setPlaceID(placeID);

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -52,10 +52,10 @@ const MainScreen: React.FC = () => {
 		const photo_reference = photos ? photos[0].photo_reference : undefined;
 		return (
 			<SubmitRatingScreen
-				placeID={placeID}
 				placeName={placeDetails?.result.name}
 				photo_reference={photo_reference}
 				setPage={setPage}
+				previousRating={previousRating}
 			/>
 		);
 	} else if (page === Screen.NotLoggedIn) {

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import StrollScreen from "./StrollScreen";
 import MapScreen from "./MapScreen";
 import DetailedViewScreen from "./DetailedViewScreen";
@@ -8,6 +8,8 @@ import LogInScreen from "./LoginScreen";
 import CreateAccountScreen from "./CreateAccountScreen";
 import NotLoggedInScreen from "./NotLoggedInScreen";
 import Screen from "../util/screens";
+import { usePreviousRating } from "../hooks/usePreviousRating";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 /**
  * Serves as the main view of the app, here all
@@ -15,13 +17,22 @@ import Screen from "../util/screens";
  * @returns the main screen component
  */
 const MainScreen: React.FC = () => {
+	const [loggedIn, setLoggedIn] = useState<boolean>(false);
 	const [page, setPage] = useState<Screen>(Screen.Home);
 	const [placeID, setPlaceID] = useState<string>();
 	const [selections, setSelections] = useState<Array<string>>([]);
+	const [email, setEmail] = useState<string | null>();
+
+	useEffect(() => {
+		(async () => {
+			setEmail(await AsyncStorage.getItem("@email"));
+		})();
+	}, [loggedIn]);
 
 	// Keep data around to avoid making another call when moving from
 	// details screen to submit rating screen
 	const { placeDetails } = useFetchPlace({ placeID });
+	const { previousRating } = usePreviousRating({ email, placeID });
 
 	//Makes new function that calls setPage with a specific argument
 	const goToMapScreen = () => setPage(Screen.Home);
@@ -63,6 +74,7 @@ const MainScreen: React.FC = () => {
 				placeID={placeID}
 				setPlaceID={setPlaceID}
 				goToSubmitRating={goToSubmitRating}
+				setLoggedIn={setLoggedIn}
 			/>
 		);
 	} else if (page === Screen.CreateAccount) {
@@ -72,6 +84,7 @@ const MainScreen: React.FC = () => {
 				placeID={placeID}
 				setPlaceID={setPlaceID}
 				goToSubmitRating={goToSubmitRating}
+				setLoggedIn={setLoggedIn}
 			/>
 		);
 	} else {

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -32,7 +32,7 @@ const MainScreen: React.FC = () => {
 	// Keep data around to avoid making another call when moving from
 	// details screen to submit rating screen
 	const { placeDetails } = useFetchPlace({ placeID });
-	const { previousRating } = usePreviousRating({ email, placeID });
+	const previousRating = usePreviousRating(email, placeID);
 
 	//Makes new function that calls setPage with a specific argument
 	const goToMapScreen = () => setPage(Screen.Home);

--- a/src/screens/SubmitRatingScreen.tsx
+++ b/src/screens/SubmitRatingScreen.tsx
@@ -2,7 +2,12 @@ import React, { useState } from "react";
 import { ScrollView, View, Text } from "react-native";
 import { PlaceImage } from "../components/PlaceImage";
 import { Button } from "../components/Button";
-import { CANCEL, getIncrementRatingButtonLabel, PLACE_ATTRIBUTES, SUBMIT } from "../util/strings";
+import {
+	S_CANCEL,
+	getIncrementRatingButtonLabel,
+	PLACE_ATTRIBUTES,
+	S_SUBMIT,
+} from "../util/strings";
 import Screen from "../util/screens";
 import { Rating } from "../util/ratingTypes";
 
@@ -19,6 +24,15 @@ const MAX_COUNT = 5;
 const MIN_COUNT = 0;
 const INCREMENT_VAL = 0.5;
 
+// key is name of attribute as we would like it rendered
+// value is name of field in the Rating type
+const attributesMap: Record<string, string> = {
+	"Navigability": "navigability",
+	"Sensory Aids": "braille", // TODO: change braille to sensory aids
+	"Staff Helpfulness": "staffHelpfulness",
+	"Guide Dog Friendliness": "guideDogFriendly",
+};
+
 const SubmitRatingScreen: React.FC<SubmitRatingScreenProps> = ({
 	placeName,
 	photo_reference,
@@ -28,19 +42,11 @@ const SubmitRatingScreen: React.FC<SubmitRatingScreenProps> = ({
 	const [counter, setCounter] = useState(
 		PLACE_ATTRIBUTES.reduce<{ [attribute: string]: number }>(function (countersMap, attribute) {
 			if (previousRating) {
-				// this smells bad
-				if (attribute === "Navigability") {
-					countersMap[attribute] = previousRating.navigability ?? DEFAULT_INTERIM_RATING;
-				} else if (attribute === "Sensory Aids") {
-					// TODO: change braille to sensory aids
-					countersMap[attribute] = previousRating.braille ?? DEFAULT_INTERIM_RATING;
-				} else if (attribute === "Staff Helpfulness") {
-					countersMap[attribute] =
-						previousRating.staffHelpfulness ?? DEFAULT_INTERIM_RATING;
-				} else if (attribute === "Guide Dog Friendliness") {
-					countersMap[attribute] =
-						previousRating.guideDogFriendly ?? DEFAULT_INTERIM_RATING;
-				}
+				// a little dirty, but we know that it will be a number
+				// as all of the keys of attributesMap are the names
+				// of the number
+				countersMap[attribute] =
+					(previousRating[attributesMap[attribute]] as number) ?? DEFAULT_INTERIM_RATING;
 			}
 			return countersMap;
 		}, {})
@@ -51,8 +57,8 @@ const SubmitRatingScreen: React.FC<SubmitRatingScreenProps> = ({
 			<PlaceImage photoref={photo_reference} placeName={placeName} />
 			<Text>{placeName}</Text>
 			<Button
-				text={CANCEL}
-				accessibilityLabel={CANCEL}
+				text={S_CANCEL}
+				accessibilityLabel={S_CANCEL}
 				onPress={() => {
 					setPage(Screen.Details);
 				}}
@@ -104,8 +110,8 @@ const SubmitRatingScreen: React.FC<SubmitRatingScreenProps> = ({
 				);
 			})}
 			<Button
-				text={SUBMIT}
-				accessibilityLabel={SUBMIT}
+				text={S_SUBMIT}
+				accessibilityLabel={S_SUBMIT}
 				onPress={() => {
 					//TODO
 				}}

--- a/src/screens/SubmitRatingScreen.tsx
+++ b/src/screens/SubmitRatingScreen.tsx
@@ -7,6 +7,7 @@ import Screen from "../util/screens";
 import { Rating } from "../util/ratingTypes";
 
 export interface SubmitRatingScreenProps {
+	placeID?: string;
 	placeName?: string;
 	photo_reference?: string;
 	setPage: (screen: Screen) => void;

--- a/src/screens/SubmitRatingScreen.tsx
+++ b/src/screens/SubmitRatingScreen.tsx
@@ -4,12 +4,13 @@ import { PlaceImage } from "../components/PlaceImage";
 import { Button } from "../components/Button";
 import { CANCEL, getIncrementRatingButtonLabel, PLACE_ATTRIBUTES, SUBMIT } from "../util/strings";
 import Screen from "../util/screens";
+import { Rating } from "../util/ratingTypes";
 
 export interface SubmitRatingScreenProps {
-	placeID?: string;
 	placeName?: string;
 	photo_reference?: string;
 	setPage: (screen: Screen) => void;
+	previousRating?: Rating | null;
 }
 
 export const DEFAULT_INTERIM_RATING = 3;
@@ -21,10 +22,25 @@ const SubmitRatingScreen: React.FC<SubmitRatingScreenProps> = ({
 	placeName,
 	photo_reference,
 	setPage,
+	previousRating,
 }: SubmitRatingScreenProps) => {
 	const [counter, setCounter] = useState(
 		PLACE_ATTRIBUTES.reduce<{ [attribute: string]: number }>(function (countersMap, attribute) {
-			countersMap[attribute] = DEFAULT_INTERIM_RATING;
+			if (previousRating) {
+				// this smells bad
+				if (attribute === "Navigability") {
+					countersMap[attribute] = previousRating.navigability ?? DEFAULT_INTERIM_RATING;
+				} else if (attribute === "Sensory Aids") {
+					// TODO: change braille to sensory aids
+					countersMap[attribute] = previousRating.braille ?? DEFAULT_INTERIM_RATING;
+				} else if (attribute === "Staff Helpfulness") {
+					countersMap[attribute] =
+						previousRating.staffHelpfulness ?? DEFAULT_INTERIM_RATING;
+				} else if (attribute === "Guide Dog Friendliness") {
+					countersMap[attribute] =
+						previousRating.guideDogFriendly ?? DEFAULT_INTERIM_RATING;
+				}
+			}
 			return countersMap;
 		}, {})
 	);

--- a/src/util/ratingTypes.ts
+++ b/src/util/ratingTypes.ts
@@ -1,0 +1,17 @@
+import type { Place } from "@googlemaps/google-maps-services-js";
+
+// TODO: export database types to own package
+// so that they do not need to be managed twice
+export interface Rating {
+	_id?: string;
+	userID: string;
+	placeID: Place["place_id"];
+	braille: number | null;
+	fontReadability: number | null;
+	staffHelpfulness: number | null;
+	navigability: number | null;
+	guideDogFriendly: number | null;
+	comment: string | null;
+	dateCreated: Date;
+	dateEdited?: Date;
+}

--- a/src/util/ratingTypes.ts
+++ b/src/util/ratingTypes.ts
@@ -3,6 +3,9 @@ import type { Place } from "@googlemaps/google-maps-services-js";
 // TODO: export database types to own package
 // so that they do not need to be managed twice
 export interface Rating {
+	// index signature: below defines what Rating types can be
+	// indexed by (indexing looks like: ex. myRating[braille])
+	[index: string]: string | number | null | Date | undefined;
 	_id?: string;
 	userID: string;
 	placeID: Place["place_id"];

--- a/src/util/strings.ts
+++ b/src/util/strings.ts
@@ -1,6 +1,8 @@
 /**
  * File to store string constants and string getter
  * functions for the project.
+ *
+ * String constants have the S_ prefix.
  */
 
 // Constants
@@ -8,14 +10,19 @@
 /**
  * Capitalized attributes of a place that can be rated by a user.
  */
+
+export const S_NAVIGABILITY = "Navigability";
+export const S_SENSORY_AIDS = "Sensory Aids";
+export const S_STAFF_HELPFULNESS = "Staff Helpfulness";
+export const S_GUIDE_DOG_FRIENDLINESS = "Guide Dog Friendliness";
 export const PLACE_ATTRIBUTES = [
-	"Navigability",
-	"Sensory Aids",
-	"Staff Helpfulness",
-	"Guide Dog Friendliness",
+	S_NAVIGABILITY,
+	S_SENSORY_AIDS,
+	S_STAFF_HELPFULNESS,
+	S_GUIDE_DOG_FRIENDLINESS,
 ];
-export const SUBMIT = "Submit";
-export const CANCEL = "Cancel";
+export const S_SUBMIT = "Submit";
+export const S_CANCEL = "Cancel";
 
 // Functions
 

--- a/src/util/strings.ts
+++ b/src/util/strings.ts
@@ -20,7 +20,7 @@ export const CANCEL = "Cancel";
 // Functions
 
 /**
- * Returns the string for the label for the button to incrememt a potential rating
+ * Returns the string for the label for the button to increment a potential rating
  * before it is submitted.
  * @param increment true for incrementing, false for decrementing
  * @param interimRating the rating that would be submitted if the user hit "Submit"


### PR DESCRIPTION
Adds a hook called `usePreviousRating` that loads the user's previous rating at the main screen component so that it can be passed to any other screen component, most notably the screen to submit a rating.

Also reorganizes the test files so that they are easier to go through.

Closes #240 