### PR TITLE
Remove filter button

### DIFF
--- a/__tests__/components/SelectionBox.test.tsx
+++ b/__tests__/components/SelectionBox.test.tsx
@@ -47,7 +47,7 @@ it("renders something", () => {
 	expect(tr.toJSON()).toBeDefined();
 });
 
-describe("Selection box tests", () => {
+describe.skip("Selection box tests", () => {
 	it("can be clicked on to show selections button", () => {
 		// Act
 		fireEvent.press(tr.getByLabelText("Show selections"));

--- a/src/components/StrollButton/FilterButton.tsx
+++ b/src/components/StrollButton/FilterButton.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { View } from "react-native";
+import { TEXT_COLOR } from "../../util/colors";
+import { Button } from "../Button";
+
+export interface FilterButtonProps {
+	setIsShowingSelections: React.Dispatch<React.SetStateAction<boolean>>;
+	isShowingSelections: boolean;
+	selections: string[];
+}
+
+const FilterButton: React.FC<FilterButtonProps> = ({
+	setIsShowingSelections,
+	isShowingSelections,
+	selections,
+}) => {
+	const buildSelectionsText = (selections: string[]) => {
+		if (selections.length === 0) return "None";
+		let text = "";
+		for (const selection of selections) {
+			text += `${selection} `;
+		}
+		return text;
+	};
+	return (
+		<View>
+			<Button
+				style={{
+					borderWidth: 3,
+					borderColor: TEXT_COLOR,
+					borderLeftWidth: 3,
+					height: "100%",
+					width: 70,
+				}}
+				onPress={() => {
+					setIsShowingSelections(!isShowingSelections);
+				}}
+				accessibilityLabel={isShowingSelections ? "Hide selections" : "Show selections"}
+				accessibilityHint={`Current selections: ${buildSelectionsText(selections)}`}
+				iconName={isShowingSelections ? "chevron-down" : "filter"}
+			/>
+		</View>
+	);
+};
+
+export default FilterButton;

--- a/src/components/StrollButton/StrollButton.tsx
+++ b/src/components/StrollButton/StrollButton.tsx
@@ -36,7 +36,6 @@ const StrollButton: React.FC<StrollButtonProps> = ({
 					{
 						borderWidth: 3,
 						borderColor: TEXT_COLOR,
-						borderRightWidth: 0,
 						height: "100%",
 					},
 					style

--- a/src/components/StrollButton/StrollButton.tsx
+++ b/src/components/StrollButton/StrollButton.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { StyleSheet, View, ViewStyle } from "react-native";
 import type { StyleProp } from "react-native";
-import { TEXT_COLOR } from "../util/colors";
+import { TEXT_COLOR } from "../../util/colors";
 
-import { Button } from "./Button";
+import { Button } from "../Button";
 
 export interface StrollButtonProps {
 	onStartStrolling: () => void;
@@ -13,21 +13,22 @@ export interface StrollButtonProps {
 	style?: StyleProp<ViewStyle>;
 }
 
+/**
+ * The button group to begin a stroll.
+ * Formerly had a filter button as part of the group, but was removed
+ * in wake of the decision to focus on showing the user only restaurants.
+ *
+ * Props:
+ * onStartStrolling,
+ * isShowingSelections (unused),
+ * setIsShowingSelections (unused),
+ * selections (unused),
+ * style,
+ */
 const StrollButton: React.FC<StrollButtonProps> = ({
 	onStartStrolling,
-	isShowingSelections: isShowingSelections,
-	setIsShowingSelections: setIsShowingSelections,
-	selections,
 	style,
 }: StrollButtonProps) => {
-	const buildSelectionsText = (selections: string[]) => {
-		if (selections.length === 0) return "None";
-		let text = "";
-		for (const selection of selections) {
-			text += `${selection} `;
-		}
-		return text;
-	};
 	return (
 		<View style={styles.buttonGroup}>
 			<Button
@@ -44,15 +45,6 @@ const StrollButton: React.FC<StrollButtonProps> = ({
 				accessibilityLabel="Take a stroll"
 				text="Take a stroll"
 			/>
-			<Button
-				style={styles.filterBtn}
-				onPress={() => {
-					setIsShowingSelections(!isShowingSelections);
-				}}
-				accessibilityLabel={isShowingSelections ? "Hide selections" : "Show selections"}
-				accessibilityHint={`Current selections: ${buildSelectionsText(selections)}`}
-				iconName={isShowingSelections ? "chevron-down" : "filter"}
-			/>
 		</View>
 	);
 };
@@ -62,14 +54,6 @@ const styles = StyleSheet.create({
 		display: "flex",
 		flexDirection: "row",
 		alignItems: "center",
-	},
-	filterBtn: {
-		borderWidth: 3,
-		borderColor: TEXT_COLOR,
-		color: TEXT_COLOR,
-		borderLeftWidth: 3,
-		height: "100%",
-		width: 70,
 	},
 });
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -4,7 +4,7 @@ import MapView, { Marker } from "react-native-maps";
 import PlaceList from "../components/Places/PlaceList";
 import SelectionBox from "../components/SelectionBox";
 import { useLocation } from "../hooks/useLocation";
-import StrollButton from "../components/StrollButton";
+import StrollButton from "../components/StrollButton/StrollButton";
 
 export interface MapScreenProps {
 	selections: string[];


### PR DESCRIPTION
Closes #268

The filter button is no longer rendered to the map screen. However, the code and tests for it remain and should be able to be re-enabled simply by putting the component back in its former position and unskipping the relevant test suite.
